### PR TITLE
Remove broken / useless `for="remember"` label attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
             <option>CA</option>
           </select>
 
-          <label for="remember">
+          <label>
             <input type="checkbox" name="remember" value="1"> Remember me
           </label>
 


### PR DESCRIPTION
If you place any input inside a label you don't need an `id` for the input and a `for` attribute for the label.

Moreover, the label I've changed is not working. If you click the text you see the checkbox does not update its state.

Since there's no need for the input `id`, I'd raether remove the `for` attribute from that label so that it works as expected.